### PR TITLE
Fixed get_windows that returns same number of samples for various window sizes

### DIFF
--- a/nina_helper/nina_helper.py
+++ b/nina_helper/nina_helper.py
@@ -678,9 +678,10 @@ def get_windows(which_reps, window_len, window_inc, emg, movements, repetitons, 
     R_data = np.zeros([targets.shape[0], ], dtype=np.int8)
     for i, win_end in enumerate(targets):
         win_start = win_end - (window_len - 1)
-        X_data[i, :, :, 0] = emg[win_start:win_end + 1, :]  # Include end
-        Y_data[i] = movements[win_end]
-        R_data[i] = repetitons[win_end]
+        if movements[win_start] == movements[win_end]:
+            X_data[i, :, :, 0] = emg[win_start:win_end + 1, :]  # Include end
+            Y_data[i] = movements[win_end]
+            R_data[i] = repetitons[win_end]
 
     return X_data, Y_data, R_data
 


### PR DESCRIPTION
Previous Issue:
The get_windows function creates same number of windows for various different window_len values. 

For example:

```
# Decide window length
window_len = 400  # Equivalent to 200ms 
window_inc = 20

# Choose subject and get info
subject = 1
info_dict = db2_info()  # Get info

db2_path = "/scratch/pp1991/DB2/DB2/DB2_s" +str(subject) + "/DB2_s" +str(subject) +  '/'

# Get EMG, repetition and movement data, cap max length of rest data before and after each movement to 5 seconds
# Capping occurs by reducing the size of repetition segments since splitting is based on repetition number
data_dict = nina_helper.import_db2(db2_path, subject)

# Create a random test - training split based on repetition number (specify a set to include)
reps = info_dict['rep_labels']
nb_test_reps = 2
nb_splits = 12
train_reps, test_reps = gen_split_rand(reps, nb_test_reps, nb_splits, base=[2, 5])

# Normalise EMG data based on training set
emg_data = normalise_emg(data_dict['emg'], data_dict['rep'], train_reps[0, :])

# Window data: x_all data is 4D tensor [observation, time_step, channel, 1] for use with Keras
# y_all: movement label, length: number of windows
# r_all: repetition label, length: number of windows
moves = np.array([i for i in range(1, 18)])
x_all, y_all, r_all = get_windows(reps, window_len, window_inc,
                                  emg_data, data_dict['move'],
                                  data_dict['rep'],
                                 which_moves=moves)
# Normalise EMG data based on training set
emg_data = normalise_emg(data_dict['emg'], data_dict['rep'], train_reps[0, :])

# Window data: x_all data is 4D tensor [observation, time_step, channel, 1] for use with Keras
# y_all: movement label, length: number of windows
# r_all: repetition label, length: number of windows

moves = np.array([i for i in range(1, 18)])
x_all, y_all, r_all = get_windows(reps, window_len, window_inc,
                                  emg_data, data_dict['move'],
                                  data_dict['rep'],
                                 which_moves=moves)

test_idx = get_idxs(r_all, test_reps[0, :])
test_data = x_all[test_idx, :, :, :]

train_idx = get_idxs(r_all, train_reps[0, :])
train_data = x_all[train_idx, :, :, :]

print(train_data.shape)
```
The above code prints the shape of the train_data as (24912, 400, 12, 1)

If I run the same code with window_len = 600, I get the shape: (24912, 600, 12, 1)

The number of samples remains the same i.e. 24912 in all cases. This cannot be the case since with increasing window length, we must have less number of windows (or samples).

I have fixed this issue in this pull request. 
The get_windows function was creating some window samples where the start index and end index of the window belonged to different gesture. This is because the target variable stores the end indexes of the window and a start index is calculated from the end index by subtracting the window_len from it. 

In some cases, the end index is at the beginning of a movement and when a window_len is subtracted from it to find the start index, the start index lies in the previous movement (in most cases the rest state). In this case, the window starts at an index where at the rest and ends at a movement.

To fix this, I ensured that the X_data, Y_data and R_data gets calculated only if the start and end of the window belong to same movement. 

```
for i, win_end in enumerate(targets):
        win_start = win_end - (window_len - 1)
        if movements[win_start] == movements[win_end]:
            X_data[i, :, :, 0] = emg[win_start:win_end + 1, :]  # Include end
            Y_data[i] = movements[win_end]
            R_data[i] = repetitons[win_end]
```

This fixed the issue and code works fine now. 